### PR TITLE
Add sort function to Transformer.afterParse sources prior to visitation

### DIFF
--- a/transform/src/index.ts
+++ b/transform/src/index.ts
@@ -149,8 +149,22 @@ export default class Transformer extends Transform {
   afterParse(parser: Parser): void {
     // Create new transform
     const transformer = new AsJSONTransform();
+    
+    // Sort the sources so that user scripts are visited last
+    const sources = parser.sources.filter(source => !isStdlib(source)).sort((_a, _b) => {
+      const a = _a.internalPath
+      const b = _b.internalPath
+      if (a[0] === "~" && b[0] !== "~") {
+        return -1;
+      } else if (a[0] !== "~" && b[0] === "~") {
+        return 1;
+      } else {
+        return 0;
+      }
+    })
+    
     // Loop over every source
-    for (const source of parser.sources) {
+    for (const source of sources) {
       // Ignore all lib and std. Visit everything else.
       if (!isStdlib(source)) {
         transformer.visit(source);


### PR DESCRIPTION
I just added a small change to the Transformer class, specifically to the afterParse method. I added a sorting function to ensure that user scripts are visited last during transformation. This is important because user scripts may reference other scripts in the project, and we want to ensure that those dependencies have been transformed first/all supporting classes encode statements have been populated.

Please let me know if you have any questions or concerns about this change.