### PR TITLE
fix: 🐛 null value throwing for some json model (nested one)

### DIFF
--- a/assembly/src/json.ts
+++ b/assembly/src/json.ts
@@ -39,7 +39,7 @@ export namespace JSON {
      */
     export function stringify<T>(data: T): string {
         // String
-        if (isString<T>()) {
+        if (isString<T>() && data != null) {
             let result = new StringSink("\"");
             // @ts-ignore
             for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
Hi! First thanks a lot for your works, the DX is really nicer than `assemblyscript-json` 

## Description

Just a quick fix about this stacktrace
![image](https://user-images.githubusercontent.com/71573572/221558717-46983f06-80d0-46f3-b09c-6e58efaf3dd0.png)

Certainly related to #28 

For null values nested like this I had some TS errors : 

```json
{
  "operations": [
    {
      "expand": null,
    ...
```

## Testing

Was unable to perform any kind of tests, tried to patch but it throws everywhere (is aspect really stable right now?)

