### PR TITLE
fix: inappropriate escape ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "Romdotdog",
     "Derek Barrera",
     "Frankk Taylor",
-    "lekiano"
+    "lekiano",
+    "Florian Guitton"
   ],
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Hi 🌴 
I hope you are having a great day !

This small PR provides a quick but perhaps inelegant fix to the inappropriate handling of escaped characters in sequences such as:
```javascript
let stringVar = '{"a":"\\\\","b":"}","c":"][","d":"\\""}';
let objectVar = {
  a: '\\', b: '}', c: '][', d: '"'
};
```