### PR TITLE
Declare types for decorators

### DIFF
--- a/assembly/__tests__/as-json.spec.ts
+++ b/assembly/__tests__/as-json.spec.ts
@@ -15,7 +15,6 @@ function canSer<T>(data: T, toBe: string): void {
   expect(serialized).toBe(toBe);
 }
 
-// @ts-ignore
 @json
 class Map4 {
   a: string;
@@ -24,7 +23,6 @@ class Map4 {
   d: string;
 }
 
-// @ts-ignore
 @json
 class Vec3 {
   x: f64;
@@ -32,7 +30,6 @@ class Vec3 {
   z: f64;
 }
 
-// @ts-ignore
 @json
 class Player {
   firstName: string;
@@ -179,7 +176,6 @@ describe("Ser externals", () => {
   })
 });
 
-// @ts-ignore
 @json
 class HttpResp {
   statusCode: number;

--- a/assembly/index.d.ts
+++ b/assembly/index.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Class decorator that enables the class to be serializable as JSON.
+ */
+declare function json(target: any): void;
+
+/**
+ * Class decorator that enables the class to be serializable as JSON.
+ */
+declare function serializable(target: any): void;
+
+/**
+ * Property decorator that provides an alias name for JSON serialization.
+ */
+declare function alias(name: string): Function;

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -1,1 +1,3 @@
+/// <reference path="./index.d.ts" />
+
 export { JSON } from "./src/json";

--- a/assembly/test.ts
+++ b/assembly/test.ts
@@ -1,6 +1,5 @@
 import { JSON } from "./src/json";
 
-// @ts-ignore
 @serializable
 class Vec3 {
     x: f64 = 3.4;
@@ -8,7 +7,6 @@ class Vec3 {
     z: f64 = 8.3;
 }
 
-// @ts-ignore
 @serializable
 class Player extends Vec3 {
     @alias("first name")


### PR DESCRIPTION
I found through experimentation that we can declare TypeScript types for decorators in a way that doesn't interfere with the AssemblyScript compiler, but still is picked up by VS Code.  This prevents red underlining our decorators, without requiring use of `// @ts-ignore` statements.  It also allows us to add jsdocs for the decorators.