### PR TITLE
fix: explicit cast from usize to u32 in outTo to silence AS201 warning

### DIFF
--- a/lib/as-bs.ts
+++ b/lib/as-bs.ts
@@ -309,7 +309,7 @@ export namespace bs {
       src = cacheOutput;
     }
     let dst = target;
-    if (changetype<OBJECT>(target - TOTAL_OVERHEAD).rtSize != len) {
+    if (changetype<OBJECT>(target - TOTAL_OVERHEAD).rtSize != <u32>len) {
       // @ts-expect-error: __renew is a runtime builtin
       dst = __renew(target, len);
     }


### PR DESCRIPTION
## Problem

Building with `json-as` on wasm targets produces warning AS201:

```
WARNING AS201: Conversion from type 'usize' to 'u32' will require an explicit cast when switching between 32/64-bit.
 :
 312 │ if (changetype<OBJECT>(target - TOTAL_OVERHEAD).rtSize != len) {
     │                                                        ~~~
     └─ in ~lib/json-as/lib/as-bs.ts(312,63)
```

In the `outTo` function, `rtSize` is `u32` but `len` is `usize`. On 64-bit targets, comparing these two types triggers AS201.

## Fix

Add an explicit `<u32>` cast on `len` in the comparison:

```diff
-    if (changetype<OBJECT>(target - TOTAL_OVERHEAD).rtSize != len) {
+    if (changetype<OBJECT>(target - TOTAL_OVERHEAD).rtSize != <u32>len) {
```

This is safe because string lengths in AssemblyScript are bounded by `u32`.
