### PR TITLE
fix: deserialize imported nested custom types

### DIFF
--- a/assembly/__tests__/custom-import.spec.ts
+++ b/assembly/__tests__/custom-import.spec.ts
@@ -6,9 +6,14 @@ import { ImportedCustomPoint } from "./fixtures/imported-custom-point";
 @json
 class ObjectWithImportedCustom {
   value: ImportedCustomPoint = new ImportedCustomPoint();
+  label: string = "";
 
-  constructor(value: ImportedCustomPoint = new ImportedCustomPoint()) {
+  constructor(
+    value: ImportedCustomPoint = new ImportedCustomPoint(),
+    label: string = "",
+  ) {
     this.value = value;
+    this.label = label;
   }
 }
 
@@ -16,28 +21,46 @@ class ObjectWithImportedCustom {
 @json
 class NullableImportedCustom {
   value: ImportedCustomPoint | null = null;
+  label: string = "";
 }
 
 describe("Should deserialize an imported custom type nested in an object", () => {
   const value = new ObjectWithImportedCustom(
     new ImportedCustomPoint(1.25, -2.5),
+    "fast",
   );
   const encoded = JSON.stringify(value);
-  expect(encoded).toBe('{"value":"1.25,-2.5"}');
+  expect(encoded).toBe('{"value":"1.25,-2.5","label":"fast"}');
 
   const parsed = JSON.parse<ObjectWithImportedCustom>(encoded);
   expect(parsed.value.x.toString()).toBe("1.25");
   expect(parsed.value.y.toString()).toBe("-2.5");
+  expect(parsed.label).toBe("fast");
   expect(JSON.stringify(parsed)).toBe(encoded);
 });
 
+describe("Should deserialize imported custom fields on the slow path", () => {
+  const parsed = JSON.parse<ObjectWithImportedCustom>(
+    '{"label":"slow","value":"6.25,-7.5"}',
+  );
+  expect(parsed.value.x.toString()).toBe("6.25");
+  expect(parsed.value.y.toString()).toBe("-7.5");
+  expect(parsed.label).toBe("slow");
+});
+
 describe("Should deserialize nullable imported custom fields", () => {
-  const parsed = JSON.parse<NullableImportedCustom>('{"value":"3.0,4.5"}');
+  const parsed = JSON.parse<NullableImportedCustom>(
+    '{"label":"value","value":"3.0,4.5"}',
+  );
   expect(parsed.value == null).toBe(false);
   expect(parsed.value!.x.toString()).toBe("3.0");
   expect(parsed.value!.y.toString()).toBe("4.5");
-  expect(JSON.stringify(parsed)).toBe('{"value":"3.0,4.5"}');
+  expect(parsed.label).toBe("value");
+  expect(JSON.stringify(parsed)).toBe('{"value":"3.0,4.5","label":"value"}');
 
-  const empty = JSON.parse<NullableImportedCustom>('{"value":null}');
+  const empty = JSON.parse<NullableImportedCustom>(
+    '{"label":"empty","value":null}',
+  );
   expect(empty.value == null).toBe(true);
+  expect(empty.label).toBe("empty");
 });

--- a/assembly/__tests__/custom-import.spec.ts
+++ b/assembly/__tests__/custom-import.spec.ts
@@ -1,0 +1,43 @@
+import { JSON } from "..";
+import { describe, expect } from "as-test";
+import { ImportedCustomPoint } from "./fixtures/imported-custom-point";
+
+
+@json
+class ObjectWithImportedCustom {
+  value: ImportedCustomPoint = new ImportedCustomPoint();
+
+  constructor(value: ImportedCustomPoint = new ImportedCustomPoint()) {
+    this.value = value;
+  }
+}
+
+
+@json
+class NullableImportedCustom {
+  value: ImportedCustomPoint | null = null;
+}
+
+describe("Should deserialize an imported custom type nested in an object", () => {
+  const value = new ObjectWithImportedCustom(
+    new ImportedCustomPoint(1.25, -2.5),
+  );
+  const encoded = JSON.stringify(value);
+  expect(encoded).toBe('{"value":"1.25,-2.5"}');
+
+  const parsed = JSON.parse<ObjectWithImportedCustom>(encoded);
+  expect(parsed.value.x.toString()).toBe("1.25");
+  expect(parsed.value.y.toString()).toBe("-2.5");
+  expect(JSON.stringify(parsed)).toBe(encoded);
+});
+
+describe("Should deserialize nullable imported custom fields", () => {
+  const parsed = JSON.parse<NullableImportedCustom>('{"value":"3.0,4.5"}');
+  expect(parsed.value == null).toBe(false);
+  expect(parsed.value!.x.toString()).toBe("3.0");
+  expect(parsed.value!.y.toString()).toBe("4.5");
+  expect(JSON.stringify(parsed)).toBe('{"value":"3.0,4.5"}');
+
+  const empty = JSON.parse<NullableImportedCustom>('{"value":null}');
+  expect(empty.value == null).toBe(true);
+});

--- a/assembly/__tests__/fixtures/imported-custom-point.ts
+++ b/assembly/__tests__/fixtures/imported-custom-point.ts
@@ -1,0 +1,31 @@
+import { JSON } from "../..";
+
+
+@json
+export class ImportedCustomPoint {
+  x: f64 = 0.0;
+  y: f64 = 0.0;
+
+  constructor(x: f64 = 0.0, y: f64 = 0.0) {
+    this.x = x;
+    this.y = y;
+  }
+
+
+  @serializer("string")
+  serializer(self: ImportedCustomPoint): string {
+    return JSON.stringify(`${self.x},${self.y}`);
+  }
+
+
+  @deserializer("string")
+  deserializer(data: string): ImportedCustomPoint {
+    const raw = JSON.parse<string>(data);
+    const separator = raw.indexOf(",");
+    if (separator < 0) throw new Error("Invalid imported custom point");
+    return new ImportedCustomPoint(
+      f64.parse(raw.slice(0, separator)),
+      f64.parse(raw.slice(separator + 1)),
+    );
+  }
+}

--- a/transform/lib/index.js
+++ b/transform/lib/index.js
@@ -1555,6 +1555,24 @@ export class JSONTransform extends Visitor {
             else if (FLOAT_TYPES.includes(resolvedType)) {
                 out.push(`${srcPtr} = __deserializeFloatField<${resolvedType}>(${valuePtr}, srcEnd, ${outPtr}, ${fieldOffset});`);
             }
+            else if (resolvedSchema?.custom) {
+                out.push("{");
+                if (member.node.type.isNullable) {
+                    out.push(`  if (load<u64>(${valuePtr}) == 30399761348886638) {`);
+                    out.push(`    store<${member.type}>(${outPtr}, changetype<${member.type}>(0), ${fieldOffset});`);
+                    out.push(`    ${srcPtr} = ${valuePtr} + 8;`);
+                    out.push("  } else {");
+                }
+                out.push(`  const valueStart = ${valuePtr};`);
+                out.push(`  const valueEnd = JSON.Util.scanValueEnd<${resolvedType}>(valueStart, srcEnd);`);
+                out.push("  if (!valueEnd) break;");
+                out.push(`  store<${member.type}>(${outPtr}, changetype<nonnull<${resolvedType}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(valueStart, valueEnd)), ${fieldOffset});`);
+                out.push(`  ${srcPtr} = valueEnd;`);
+                if (member.node.type.isNullable) {
+                    out.push("  }");
+                }
+                out.push("}");
+            }
             else if (resolvedSchema && !resolvedSchema.custom) {
                 if (fastPath) {
                     out.push("{");
@@ -2474,6 +2492,11 @@ export class JSONTransform extends Visitor {
             if (member.flags.has(PropertyFlags.Lazy))
                 return getLazyRangeStore(member, valueStart, valueEnd, prefix);
             const offset = JSON.stringify(member.name);
+            const memberSchema = this.getSchema(member.type);
+            if (memberSchema?.custom) {
+                return (prefix +
+                    `store<${member.type}>(changetype<usize>(out), changetype<nonnull<${stripNull(member.type)}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(${valueStart}, ${valueEnd})), offsetof<this>(${offset}));\n`);
+            }
             if (needsReferenceLoad(member.type)) {
                 return (prefix +
                     `store<${member.type}>(changetype<usize>(out), JSON.__deserialize<${member.type}>(${valueStart}, ${valueEnd}, changetype<usize>(load<${member.type}>(changetype<usize>(out), offsetof<this>(${offset})))), offsetof<this>(${offset}));\n`);
@@ -3156,9 +3179,15 @@ export class JSONTransform extends Visitor {
     }
     getSchema(name) {
         name = stripNull(name);
-        return (this.schemas
+        const local = this.schemas
             .get(this.schema.node.range.source.internalPath)
-            .find((s) => s.name == name) || null);
+            .find((s) => s.name == name) || null;
+        if (local)
+            return local;
+        return (this.schema.deps.find((schema) => schema &&
+            (schema.name == name ||
+                schema.name.endsWith("." + name) ||
+                name.endsWith("." + schema.name))) || null);
     }
     generateEmptyMethods(node) {
         const SERIALIZE_EMPTY = "__SERIALIZE(ptr: usize): void {\n  bs.proposeSize(4);\n  store<u32>(bs.offset, 8192123);\n  bs.offset += 4;\n}";

--- a/transform/lib/index.js
+++ b/transform/lib/index.js
@@ -1400,6 +1400,7 @@ export class JSONTransform extends Visitor {
         const INTEGER_TYPES = [...UNSIGNED_INTEGER_TYPES, ...SIGNED_INTEGER_TYPES];
         const STRING_FIELD_DESERIALIZER = "__deserializeStringField";
         const STRING_FIELD_TRUSTED_DESERIALIZER = "__deserializeStringFieldTrusted";
+        const getCustomDeserializeExpression = (type, valueStart, valueEnd) => `changetype<nonnull<${stripNull(type)}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(${valueStart}, ${valueEnd}))`;
         const getArrayValueType = (type) => {
             if (!type.startsWith("Array<") && !type.startsWith("StaticArray<"))
                 return null;
@@ -1566,7 +1567,7 @@ export class JSONTransform extends Visitor {
                 out.push(`  const valueStart = ${valuePtr};`);
                 out.push(`  const valueEnd = JSON.Util.scanValueEnd<${resolvedType}>(valueStart, srcEnd);`);
                 out.push("  if (!valueEnd) break;");
-                out.push(`  store<${member.type}>(${outPtr}, changetype<nonnull<${resolvedType}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(valueStart, valueEnd)), ${fieldOffset});`);
+                out.push(`  store<${member.type}>(${outPtr}, ${getCustomDeserializeExpression(resolvedType, "valueStart", "valueEnd")}, ${fieldOffset});`);
                 out.push(`  ${srcPtr} = valueEnd;`);
                 if (member.node.type.isNullable) {
                     out.push("  }");
@@ -2495,7 +2496,7 @@ export class JSONTransform extends Visitor {
             const memberSchema = this.getSchema(member.type);
             if (memberSchema?.custom) {
                 return (prefix +
-                    `store<${member.type}>(changetype<usize>(out), changetype<nonnull<${stripNull(member.type)}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(${valueStart}, ${valueEnd})), offsetof<this>(${offset}));\n`);
+                    `store<${member.type}>(changetype<usize>(out), ${getCustomDeserializeExpression(member.type, valueStart, valueEnd)}, offsetof<this>(${offset}));\n`);
             }
             if (needsReferenceLoad(member.type)) {
                 return (prefix +
@@ -3184,10 +3185,11 @@ export class JSONTransform extends Visitor {
             .find((s) => s.name == name) || null;
         if (local)
             return local;
-        return (this.schema.deps.find((schema) => schema &&
-            (schema.name == name ||
-                schema.name.endsWith("." + name) ||
-                name.endsWith("." + schema.name))) || null);
+        const exact = this.schema.deps.filter((schema) => schema && schema.name == name);
+        if (exact.length == 1)
+            return exact[0];
+        const qualified = this.schema.deps.filter((schema) => schema && schema.name.endsWith("." + name));
+        return qualified.length == 1 ? qualified[0] : null;
     }
     generateEmptyMethods(node) {
         const SERIALIZE_EMPTY = "__SERIALIZE(ptr: usize): void {\n  bs.proposeSize(4);\n  store<u32>(bs.offset, 8192123);\n  bs.offset += 4;\n}";

--- a/transform/src/index.ts
+++ b/transform/src/index.ts
@@ -2324,6 +2324,29 @@ export class JSONTransform extends Visitor {
         out.push(
           `${srcPtr} = __deserializeFloatField<${resolvedType}>(${valuePtr}, srcEnd, ${outPtr}, ${fieldOffset});`,
         );
+      } else if (resolvedSchema?.custom) {
+        out.push("{");
+        if (member.node.type.isNullable) {
+          out.push(`  if (load<u64>(${valuePtr}) == 30399761348886638) {`);
+          out.push(
+            `    store<${member.type}>(${outPtr}, changetype<${member.type}>(0), ${fieldOffset});`,
+          );
+          out.push(`    ${srcPtr} = ${valuePtr} + 8;`);
+          out.push("  } else {");
+        }
+        out.push(`  const valueStart = ${valuePtr};`);
+        out.push(
+          `  const valueEnd = JSON.Util.scanValueEnd<${resolvedType}>(valueStart, srcEnd);`,
+        );
+        out.push("  if (!valueEnd) break;");
+        out.push(
+          `  store<${member.type}>(${outPtr}, changetype<nonnull<${resolvedType}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(valueStart, valueEnd)), ${fieldOffset});`,
+        );
+        out.push(`  ${srcPtr} = valueEnd;`);
+        if (member.node.type.isNullable) {
+          out.push("  }");
+        }
+        out.push("}");
       } else if (resolvedSchema && !resolvedSchema.custom) {
         if (fastPath) {
           out.push("{");
@@ -3567,6 +3590,13 @@ export class JSONTransform extends Visitor {
       if (member.flags.has(PropertyFlags.Lazy))
         return getLazyRangeStore(member, valueStart, valueEnd, prefix);
       const offset = JSON.stringify(member.name);
+      const memberSchema = this.getSchema(member.type);
+      if (memberSchema?.custom) {
+        return (
+          prefix +
+          `store<${member.type}>(changetype<usize>(out), changetype<nonnull<${stripNull(member.type)}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(${valueStart}, ${valueEnd})), offsetof<this>(${offset}));\n`
+        );
+      }
       // TypedArrays and ArrayBuffer are reference types whose JSON form is
       // `[...]`. Pass the existing field pointer as `dst` so the deserializer
       // can reuse the allocation when size matches instead of always allocating.
@@ -4515,10 +4545,20 @@ export class JSONTransform extends Visitor {
   }
   getSchema(name: string): Schema | null {
     name = stripNull(name);
-    return (
+    const local =
       this.schemas
         .get(this.schema.node.range.source.internalPath)
-        .find((s) => s.name == name) || null
+        .find((s) => s.name == name) || null;
+    if (local) return local;
+
+    return (
+      this.schema.deps.find(
+        (schema) =>
+          schema &&
+          (schema.name == name ||
+            schema.name.endsWith("." + name) ||
+            name.endsWith("." + schema.name)),
+      ) || null
     );
   }
   generateEmptyMethods(node: ClassDeclaration): void {

--- a/transform/src/index.ts
+++ b/transform/src/index.ts
@@ -2108,6 +2108,16 @@ export class JSONTransform extends Visitor {
     const STRING_FIELD_DESERIALIZER = "__deserializeStringField";
     const STRING_FIELD_TRUSTED_DESERIALIZER = "__deserializeStringFieldTrusted";
 
+    // Custom deserializers are instance methods, but generated code must invoke
+    // them before an instance exists. AssemblyScript's static dispatch lets a
+    // zero reference select the method without dereferencing `this`.
+    const getCustomDeserializeExpression = (
+      type: string,
+      valueStart: string,
+      valueEnd: string,
+    ): string =>
+      `changetype<nonnull<${stripNull(type)}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(${valueStart}, ${valueEnd}))`;
+
     const getArrayValueType = (type: string): string | null => {
       if (!type.startsWith("Array<") && !type.startsWith("StaticArray<"))
         return null;
@@ -2340,7 +2350,7 @@ export class JSONTransform extends Visitor {
         );
         out.push("  if (!valueEnd) break;");
         out.push(
-          `  store<${member.type}>(${outPtr}, changetype<nonnull<${resolvedType}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(valueStart, valueEnd)), ${fieldOffset});`,
+          `  store<${member.type}>(${outPtr}, ${getCustomDeserializeExpression(resolvedType, "valueStart", "valueEnd")}, ${fieldOffset});`,
         );
         out.push(`  ${srcPtr} = valueEnd;`);
         if (member.node.type.isNullable) {
@@ -3594,7 +3604,7 @@ export class JSONTransform extends Visitor {
       if (memberSchema?.custom) {
         return (
           prefix +
-          `store<${member.type}>(changetype<usize>(out), changetype<nonnull<${stripNull(member.type)}>>(0).__DESERIALIZE_CUSTOM(JSON.Util.ptrToStr(${valueStart}, ${valueEnd})), offsetof<this>(${offset}));\n`
+          `store<${member.type}>(changetype<usize>(out), ${getCustomDeserializeExpression(member.type, valueStart, valueEnd)}, offsetof<this>(${offset}));\n`
         );
       }
       // TypedArrays and ArrayBuffer are reference types whose JSON form is
@@ -4551,15 +4561,18 @@ export class JSONTransform extends Visitor {
         .find((s) => s.name == name) || null;
     if (local) return local;
 
-    return (
-      this.schema.deps.find(
-        (schema) =>
-          schema &&
-          (schema.name == name ||
-            schema.name.endsWith("." + name) ||
-            name.endsWith("." + schema.name)),
-      ) || null
+    const exact = this.schema.deps.filter(
+      (schema) => schema && schema.name == name,
     );
+    if (exact.length == 1) return exact[0];
+
+    // A short type spelling can refer to a namespaced dependency. Accept that
+    // fallback only when it identifies one schema; selecting the first suffix
+    // match could silently call an unrelated type's custom deserializer.
+    const qualified = this.schema.deps.filter(
+      (schema) => schema && schema.name.endsWith("." + name),
+    );
+    return qualified.length == 1 ? qualified[0] : null;
   }
   generateEmptyMethods(node: ClassDeclaration): void {
     const SERIALIZE_EMPTY =


### PR DESCRIPTION
Resolve schemas from explicit dependencies and invoke custom deserializers when an imported custom type is nested inside another @json class.

Add regression coverage for normal and nullable imported custom fields.

Fixes #214

⚠️ Full disclaimer: This PR was created by ChatGPT 5.6 Terra (Medium), I honestly do not understand if the code is correct, @JairusSW please feel free to close this PR and create one of your own ⚠️

But please do ping me when the new release fixes the issue

Cheers!